### PR TITLE
forgot to turn on puppi met

### DIFF
--- a/Configuration/python/BambuProdAodsim.py
+++ b/Configuration/python/BambuProdAodsim.py
@@ -8,7 +8,7 @@ process = cms.Process('FILEFI')
 
 # say how many events to process (-1 means no limit)
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(10)
+  input = cms.untracked.int32(100)
 )
 
 #>> input source

--- a/TreeFiller/python/MitTreeFiller_cfi.py
+++ b/TreeFiller/python/MitTreeFiller_cfi.py
@@ -62,6 +62,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     'AKt8FatJetsPuppi',
     'CA15FatJetsPuppi',
     'PFMet',
+    'PuppiMet',
     'CaloMet',
     'HPSTaus',
     'DCASig'


### PR DESCRIPTION
Also, the difference between 74X and 76X is understood: due to a low PU correction that was modified slightly. Checked with Phil, he is confident 76X is the version to use. So, we can proceed with the defaults.